### PR TITLE
Set increased timeout for ContentType operations

### DIFF
--- a/jvcprojector/command/command.py
+++ b/jvcprojector/command/command.py
@@ -1598,6 +1598,7 @@ class ContentType(Command):
     code = "PMCT"
     reference = True
     operation = True
+    operation_timeout = 10.0
 
     AUTO = "auto"
     SDR = "sdr"


### PR DESCRIPTION
I maintain an integration for the [Unfolded Circle](https://github.com/unfoldedcircle) line of remotes which relies on your jvc library. 2.0 was a fantasitic upgrade, btw. 

I user is receiving a timeout error when setting the content type on their projector and I believe this change should address the problem. I don't have a projector that supports these values so I can't test it myself but due to the simplicity of the change and how it mimics existing timeout behavior for other operations, I thought it might be safe enough for you to consider pulling in. 

If needed, I can distribute a patched copy of the library and let him test that. Just let me know. Or if you would like me to include any tests with this change. 

Thanks for the great library!